### PR TITLE
Cleanup

### DIFF
--- a/hotkeymap.h
+++ b/hotkeymap.h
@@ -131,8 +131,8 @@ inline size_t QtKeyToWin(Qt::Key key)
 #include "X11/keysym.h"
 
 struct UKeyData {
-    int key;
-    int mods;
+    xcb_keysym_t key;
+    uint16_t mods;
 };
 
 static std::unordered_map<uint32_t, uint32_t> KEY_MAP = {

--- a/uglobalhotkeys.cpp
+++ b/uglobalhotkeys.cpp
@@ -13,13 +13,13 @@
 #include <QDebug>
 
 UGlobalHotkeys::UGlobalHotkeys(QWidget *parent)
-    : QWidget(parent)
+    : QObject(parent)
 {
 #if defined(Q_OS_LINUX)
     qApp->installNativeEventFilter(this);
     QWindow wndw;
     void *v = qApp->platformNativeInterface()->nativeResourceForWindow("connection", &wndw);
-    X11Connection = (xcb_connection_t *)v;
+    X11Connection = static_cast<xcb_connection_t *>(v);
     X11Wid = xcb_setup_roots_iterator(xcb_get_setup(X11Connection)).data->root;
     X11KeySymbs = xcb_key_symbols_alloc(X11Connection);
 #endif
@@ -188,8 +188,8 @@ bool UGlobalHotkeys::nativeEventFilter(const QByteArray &eventType, void *messag
 bool UGlobalHotkeys::linuxEvent(xcb_generic_event_t *message)
 {
     if ((message->response_type & ~0x80) == XCB_KEY_PRESS) {
-        xcb_key_press_event_t *ev = (xcb_key_press_event_t *)message;
-        auto ind = Registered.key({ev->detail, (ev->state & ~XCB_MOD_MASK_2)});
+        xcb_key_press_event_t *ev = reinterpret_cast<xcb_key_press_event_t *>(message);
+        auto ind = Registered.key({ev->detail, uint16_t(ev->state & ~XCB_MOD_MASK_2)});
 
         if (ind == 0) // this is not hotkeys
             return false;
@@ -207,7 +207,7 @@ void UGlobalHotkeys::regLinuxHotkey(const UKeySequence &keySeq, size_t id)
     
     xcb_keycode_t *keyC = xcb_key_symbols_get_keycode(X11KeySymbs, keyData.key);
 
-    if (keyC == XCB_NO_SYMBOL) { // 0x0
+    if (keyC == nullptr) {
         qWarning() << "Cannot find symbol";
         return;
     }

--- a/uglobalhotkeys.h
+++ b/uglobalhotkeys.h
@@ -17,7 +17,7 @@
 #if defined(Q_OS_LINUX)
 struct UHotkeyData {
     xcb_keycode_t keyCode;
-    int mods;
+    uint16_t mods;
     bool operator ==(const UHotkeyData &data) const
     {
         return data.keyCode == this->keyCode && data.mods == this->mods;
@@ -25,7 +25,7 @@ struct UHotkeyData {
 };
 #endif
 
-class UGLOBALHOTKEY_EXPORT UGlobalHotkeys : public QWidget
+class UGLOBALHOTKEY_EXPORT UGlobalHotkeys : public QObject
 #if defined(Q_OS_LINUX)
     , public QAbstractNativeEventFilter
 #endif
@@ -33,7 +33,7 @@ class UGLOBALHOTKEY_EXPORT UGlobalHotkeys : public QWidget
     Q_OBJECT
 
 public:
-    explicit UGlobalHotkeys(QWidget *parent = 0);
+    explicit UGlobalHotkeys(QWidget *parent = nullptr);
     bool registerHotkey(const QString &keySeq, size_t id = 1);
     bool registerHotkey(const UKeySequence &keySeq, size_t id = 1);
     void unregisterHotkey(size_t id = 1);

--- a/ukeysequence.cpp
+++ b/ukeysequence.cpp
@@ -106,7 +106,7 @@ void UKeySequence::addKey(const QString &key)
         qWarning() << "Wrong key";
         return;
     }
-    addKey((Qt::Key) seq[0]);
+    addKey(static_cast<Qt::Key>(seq[0]));
 }
 
 void UKeySequence::addKey(Qt::Key key)
@@ -125,6 +125,6 @@ void UKeySequence::addKey(Qt::Key key)
 
 void UKeySequence::addKey(const QKeyEvent *event)
 {
-    addKey((Qt::Key) event->key());
+    addKey(static_cast<Qt::Key>(event->key()));
     addModifiers(event->modifiers());
 }

--- a/ukeysequence.h
+++ b/ukeysequence.h
@@ -13,8 +13,8 @@ class UGLOBALHOTKEY_EXPORT UKeySequence : public QObject
     Q_OBJECT
 
 public:
-    explicit UKeySequence(QObject *parent = 0);
-    explicit UKeySequence(const QString &str, QObject *parent = 0);
+    explicit UKeySequence(QObject *parent = nullptr);
+    explicit UKeySequence(const QString &str, QObject *parent = nullptr);
 
     void fromString(const QString &str);
     QString toString();
@@ -23,13 +23,13 @@ public:
     void addModifiers(Qt::KeyboardModifiers mod);
     void addKey(const QKeyEvent *event);
 
-    inline size_t size() const
+    inline int size() const
     {
         return mKeys.size();
     }
-    inline Qt::Key operator [](size_t n) const
+    inline Qt::Key operator [](int n) const
     {
-        if ((int)n > mKeys.size()) {
+        if (n > mKeys.size()) {
             return Qt::Key_unknown;
         }
 
@@ -70,4 +70,3 @@ private:
     }
 
 };
-


### PR DESCRIPTION
* Replace parent of UGlobalHotkeys from QWidget to QParent
* Use nullptr where applicable
* Avoid C-style casts
* Make types consistent